### PR TITLE
Fix "undefined" message

### DIFF
--- a/Polyglot.safariextension/api.js
+++ b/Polyglot.safariextension/api.js
@@ -1,6 +1,8 @@
 import url from 'url'
 import 'whatwg-fetch' // eslint-disable-line import/no-unassigned-import
 
+const REQUEST_LIMIT_EXCEEDED = 'Error: external API request limit exceeded. Please try again later.'
+
 export async function translate(text, targetLanguage) {
   const query = url.format({
     query: {
@@ -15,6 +17,9 @@ export async function translate(text, targetLanguage) {
 
   try {
     const response = await fetch(endpoint)
+    if (response.status === 503) {
+      return REQUEST_LIMIT_EXCEEDED
+    }
     const body = await response.text()
     const data = JSON.parse(
       body.replace(/,,/g, ',null,').replace(/,,/g, ',null,')


### PR DESCRIPTION
Guys, Happy New Year 🎄

It fixes #41 and #42.

Looks like Goole has a limitation on the number of api calls for ip.
Instead of the `undefined` message, a more understandable message will be displayed.

Now it looks like this:

<img width="925" alt="screenshot at jan 01 15-13-24" src="https://user-images.githubusercontent.com/5787193/50572780-c58d9c80-0dd8-11e9-8cfe-05df288f0294.png">

Maybe the message text need to be corrected, if you have any ideas please let me know.