### PR TITLE
Change default "instantTranslation" value

### DIFF
--- a/Polyglot.safariextension/Settings.plist
+++ b/Polyglot.safariextension/Settings.plist
@@ -202,7 +202,7 @@
 	</dict>
 	<dict>
 		<key>DefaultValue</key>
-		<string>false</string>
+		<string>true</string>
 		<key>Key</key>
 		<string>instantTranslation</string>
 		<key>Title</key>


### PR DESCRIPTION
For: **Wrong default value for `Instant translation` feature in Settings Panel #46**

Default value for 'Instant translation' in the Safari Settings Panel: false
Behavior of 'Instant translation' panel: true (ie appears)

To resolve, try switching default value from false to true. 

If commit doesn't resolve issue, try changing logic in following file: 
_Polyglot.safariextension/injected.js_ 
line: 
_102_

`if (!settings.instantTranslation || e.target.id === PANEL_ID) {
`

Suggestion:
Remove '`!`' to make  `if (settings.instantTranslation || e.target.id === PANEL_ID) { `

If this doesn't resolve the problem either, perhaps the issue is that the first run is not calling the 'Instant translation' value for some reason. 

