### PR TITLE
Disable useless full screen button

### DIFF
--- a/Polyglot/Base.lproj/MainMenu.xib
+++ b/Polyglot/Base.lproj/MainMenu.xib
@@ -686,7 +686,7 @@
             <point key="canvasLocation" x="90" y="80"/>
         </menu>
         <window title="Polyglot" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="QvC-M9-y7g">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="449" height="179"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>


### PR DESCRIPTION
It was stretching the settings window to the whole screen, putting window content in the middle with a big about of empty space around 🤷‍♀️